### PR TITLE
Chris coastal/update

### DIFF
--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -13,10 +13,8 @@ import ProjectLede from '@/components/ProjectPage/ProjectLede/ProjectLede';
 import ProjectTitle from '@/components/ProjectPage/ProjectTitle/ProjectTitle';
 import ProjectVideo from '@/components/ProjectPage/ProjectVideo/ProjectVideo';
 import HomeButton from '@/components/UI/HomeButton/HomeButton';
-import useResizeWindow from '@/hooks/useResizeWindow';
 
 const ProjectPage: FC = () => {
-  const { windowSize } = useResizeWindow();
   const pathId = usePathname().split('/').pop();
   const project = Object.values(projectContent).find(
     (project) => project.id === pathId
@@ -36,7 +34,6 @@ const ProjectPage: FC = () => {
             headerImages={project.headerImages}
             gitHubLink={project.links.gitHub}
             siteLink={project.links.site}
-            innerWidth={windowSize.innerWidth}
           />
 
           <div className="mb-36 mt-16 flex flex-col gap-24">

--- a/src/app/projects/layout.tsx
+++ b/src/app/projects/layout.tsx
@@ -10,8 +10,7 @@ type ProjectsLayoutProps = {
 const ProjectsLayout: FC<ProjectsLayoutProps> = ({ children }) => {
   return (
     <div className="bg-white">
-      {/* <HomeButton /> */}
-      <div className="mx-6 flex justify-center pb-12 pt-20 sm:mx-8 sm:pb-24">
+      <div className="mx-24 flex justify-center pb-12 pt-20 sm:mx-8 sm:pb-24">
         <div className="max-w-[72rem]">{children}</div>
       </div>
     </div>

--- a/src/components/ProjectPage/ProjectBottomNav/ProjectBottomNav.tsx
+++ b/src/components/ProjectPage/ProjectBottomNav/ProjectBottomNav.tsx
@@ -10,7 +10,7 @@ type ProjectBottomNavProps = {
 
 const ProjectBottomNav: FC<ProjectBottomNavProps> = ({ prev, next }) => {
   return (
-    <div className="flex justify-between">
+    <div className="mx-4 flex justify-between">
       <div className="flex items-center">
         <ClickableCursor text="prev">
           <Link
@@ -27,7 +27,7 @@ const ProjectBottomNav: FC<ProjectBottomNavProps> = ({ prev, next }) => {
         <ClickableCursor text="prev">
           <Link
             href={`/projects/${prev.link}`}
-            className="-translate-x-4 text-sm sm:text-base"
+            className="text-sm sm:text-base"
           >
             {prev.title}
           </Link>
@@ -38,7 +38,7 @@ const ProjectBottomNav: FC<ProjectBottomNavProps> = ({ prev, next }) => {
         <ClickableCursor text="next">
           <Link
             href={`/projects/${next.link}`}
-            className="translate-x-4 text-sm sm:text-base"
+            className="text-right text-sm sm:text-base"
           >
             {next.title}
           </Link>

--- a/src/components/ProjectPage/ProjectHeader/ProjectHeader.tsx
+++ b/src/components/ProjectPage/ProjectHeader/ProjectHeader.tsx
@@ -8,14 +8,12 @@ import { breakPoints } from '@/constants/constants';
 
 type ProjectHeaderProps = {
   headerImages: (ImageData & { zIndex: string })[];
-  innerWidth: number;
   gitHubLink: string | undefined;
   siteLink: string | undefined;
 };
 
 const ProjectHeader: FC<ProjectHeaderProps> = ({
   headerImages,
-  innerWidth,
   gitHubLink,
   siteLink,
 }) => {
@@ -38,11 +36,7 @@ const ProjectHeader: FC<ProjectHeaderProps> = ({
           priority
         />
       ))}
-      <ProjectLinks
-        gitHub={gitHubLink}
-        site={siteLink}
-        innerWidth={innerWidth}
-      />
+      <ProjectLinks gitHub={gitHubLink} site={siteLink} />
     </div>
   );
 };

--- a/src/components/ProjectPage/ProjectLinks/ProjectLinks.tsx
+++ b/src/components/ProjectPage/ProjectLinks/ProjectLinks.tsx
@@ -9,11 +9,10 @@ import { breakPoints } from '@/constants/constants';
 type ProjectLinksProps = {
   gitHub?: string;
   site?: string;
-  innerWidth: number;
 };
 
 const ProjectLinks: FC<ProjectLinksProps> = ({ gitHub, site }) => {
-  const size = innerWidth < breakPoints.md ? '36px' : '32px';
+  const size = '32px';
 
   return (
     <div className="col-span-3 mb-4 flex items-center justify-end gap-8 self-start md:gap-6">

--- a/src/components/UI/CodeBlock/CodeBlock.tsx
+++ b/src/components/UI/CodeBlock/CodeBlock.tsx
@@ -1,18 +1,11 @@
 'use client';
 import React, { FC, ReactNode, useEffect } from 'react';
 import { highlightAll } from 'prismjs';
-import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
-import tsx from 'react-syntax-highlighter/dist/cjs/languages/prism/tsx';
-import { monokai } from 'react-syntax-highlighter/dist/esm/styles/hljs';
-
-import useResizeWindow from '@/hooks/useResizeWindow';
 
 import 'prismjs/themes/prism-okaidia.css';
 
 type CodeBlockProps = {
   children?: ReactNode;
-  code?: string;
-  width?: number;
   language?: string;
   fileName?: string;
   className?: string;
@@ -20,8 +13,6 @@ type CodeBlockProps = {
 
 const CodeBlock: FC<CodeBlockProps> = ({
   children,
-  code,
-  width,
   language = 'js',
   fileName,
   className,
@@ -31,32 +22,21 @@ const CodeBlock: FC<CodeBlockProps> = ({
     highlightAll();
   }, [children]);
 
-  const { windowSize: size } = useResizeWindow();
-
-  // useEffect(() => {
-  //   const codeContainer = document.getElementById('code');
-  // }, [size]);
-
-  // const width = size.innerWidth - 200;
-
   return (
     <div className="bg-stone-800">
-      <div style={{ width: width || 0 - 12 }} className="ml-2">
+      <div className="ml-2">
         {fileName ? (
           <h4 className="!text-xs text-white sm:!text-sm">{fileName}</h4>
         ) : null}
-        <pre
-          className={`language-${language} invert-scrollbar !m-0 !whitespace-pre !rounded-none border border-stone-400/40 !bg-stone-800 text-sm`}
+        <div
+          className={`language-${language} invert-scrollbar !m-0 !rounded-none border border-stone-400/40 !bg-stone-800 text-sm`}
         >
           <code
-            className={`${className} language-${language} !m-0 !bg-stone-800 !text-2xs sm:!text-sm`}
+            className={`${className} language-${language} !m-0 overflow-x-scroll !whitespace-pre !bg-stone-800 !text-2xs sm:!text-sm`}
           >
             {children}
-            {/* <SyntaxHighlighter language="tsx" style={monokai}>
-          {code}
-        </SyntaxHighlighter> */}
           </code>
-        </pre>
+        </div>
       </div>
     </div>
   );

--- a/src/components/UI/CodeBlock/CodeBlock.tsx
+++ b/src/components/UI/CodeBlock/CodeBlock.tsx
@@ -24,15 +24,15 @@ const CodeBlock: FC<CodeBlockProps> = ({
 
   return (
     <div className="bg-stone-800">
-      <div className="ml-2">
+      <div className="ml-2 overflow-x-hidden">
         {fileName ? (
           <h4 className="!text-xs text-white sm:!text-sm">{fileName}</h4>
         ) : null}
         <div
-          className={`language-${language} invert-scrollbar !m-0 !rounded-none border border-stone-400/40 !bg-stone-800 text-sm`}
+          className={`language-${language} invert-scrollbar !m-0 overflow-x-scroll !rounded-none border border-stone-400/40 !bg-stone-800 text-sm`}
         >
           <code
-            className={`${className} language-${language} !m-0 overflow-x-scroll !whitespace-pre !bg-stone-800 !text-2xs sm:!text-sm`}
+            className={`${className} language-${language} !m-0 !whitespace-pre !bg-stone-800 !text-2xs sm:!text-sm`}
           >
             {children}
           </code>

--- a/src/components/UI/CodeDropDown/CodeDropDown.tsx
+++ b/src/components/UI/CodeDropDown/CodeDropDown.tsx
@@ -85,7 +85,7 @@ const CodeDropDown: FC<CodeDropDownProps> = ({
       <animated.div
         style={{
           maxHeight: dropDownStyles.height,
-          width: '96vw',
+          width: '90vw',
           maxWidth: '72rem',
           opacity: dropDownStyles.opacity,
         }}
@@ -98,7 +98,6 @@ const CodeDropDown: FC<CodeDropDownProps> = ({
             key={snippet.fileName}
             language={snippet.language}
             fileName={snippet.fileName}
-            code={snippet.code}
           >
             {snippet.code}
           </CodeBlock>

--- a/src/components/UI/HomeButton/HomeButton.tsx
+++ b/src/components/UI/HomeButton/HomeButton.tsx
@@ -15,7 +15,7 @@ const ProjectNav = () => {
   //     ? (windowSize.innerWidth - PROJECT_CONTAINER_WIDTH) / 2 + 1
   //     : 10;
 
-  const top = !scroll.isDown || scroll.pos === 0 ? 24 : -32;
+  const top = !scroll.isDown || scroll.pos < 20 ? 24 : -48;
 
   return (
     <div className="relative z-[500] flex justify-end">


### PR DESCRIPTION
This pull request removes the `<pre>` tag from the CodeDropDown component on the ProjectPages, as it was causing unpredictable formatting, and replacing it with `white-space: pre` on the `<code>` element itself.